### PR TITLE
Modernize namespace packaging

### DIFF
--- a/py/htm/__init__.py
+++ b/py/htm/__init__.py
@@ -21,7 +21,6 @@ Most classes in this package support pickling, meaning that they can be
 serialize and deserialized with the standard library's pickle module.
 """
 
-__import__('pkg_resources').declare_namespace(__name__)
 
 from htm.bindings.sdr  import *
 

--- a/py/htm/advanced/examples/single_layer_2d_experiment/visualizations/py/setup.py
+++ b/py/htm/advanced/examples/single_layer_2d_experiment/visualizations/py/setup.py
@@ -19,13 +19,13 @@
 # http://numenta.org/licenses/
 # ----------------------------------------------------------------------
 
-from setuptools import find_packages, setup
+from setuptools import find_namespace_packages, setup
 
 setup(
     name="htmresearchviz0",
     version="0.0.1",
     description="",
-    packages=find_packages(),
+    packages=find_namespace_packages(include=["htmresearchviz0*"]),
     package_data={
         "htmresearchviz0": [
             "htmresearchviz0/package_data/*",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,6 +97,11 @@ sdist.include = ["build/Thirdparty", "build/Release"]   # for external dependenc
 [tool.setuptools.package-data]
 htm = ["data/mnist/*"]
 
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["htm*"]
+namespaces = true
+
 		   
 
 


### PR DESCRIPTION
## Summary
- remove deprecated `pkg_resources.declare_namespace` usage
- configure setuptools to use namespace packages
- update example `setup.py` to `find_namespace_packages`

## Testing
- `python -m pip install -e .` *(fails: missing libhtm_core.a)*
- `pytest -k nothing py/tests` *(fails: ModuleNotFoundError: No module named 'htm')*

------
https://chatgpt.com/codex/tasks/task_e_686e6e99b2f8832f85bac7204488c662