### PR TITLE
Fix TOML loading in install script

### DIFF
--- a/htm_install.py
+++ b/htm_install.py
@@ -63,8 +63,9 @@ def main():
         import toml
     else:
         import tomllib as toml
-    with open("pyproject.toml", "rb") as f:
-        pyproject = toml.load(f)
+    # Use toml.load with the file path so it handles opening in text mode.
+    # Using binary mode causes a TypeError on some versions of toml/tomllib.
+    pyproject = toml.load("pyproject.toml")
         
     project_version = pyproject["project"]["version"]
     print(f"Version: {project_version}")


### PR DESCRIPTION
## Summary
- avoid opening `pyproject.toml` in binary mode in `htm_install.py`

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'htm')*

------
https://chatgpt.com/codex/tasks/task_e_68755db121fc832fae96afc674443a56